### PR TITLE
chore: update `@whizark/remark-preset` to version `~0.3.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "devDependencies": {
         "remark-cli"            : "~2.1.0",
         "remark-lint"           : "~5.2.0",
-        "@whizark/remark-preset": "~0.2.0"
+        "@whizark/remark-preset": "~0.3.0"
     },
     "private"        : true
 }


### PR DESCRIPTION
Update [@whizark/remark-preset](https://www.npmjs.com/package/@whizark/remark-preset) [:octocat:](https://github.com/whizark/remark-preset) version `~0.2.0` to `~0.3.0` (`devDependencies`).
## November 3, 2016
  * [`028c73a`](https://github.com/whizark/remark-preset/commit/028c73abe48db6a5a863cbc8d35938195a4c7d17) <code>bump version to 0.3.0</code>
  * [`c2352da`](https://github.com/whizark/remark-preset/commit/c2352da69a13f7127d5d222b8b8f82d178b531b3) <code>update remark-lint to 5.2.0</code>
  * [`6cc06a7`](https://github.com/whizark/remark-preset/commit/6cc06a759b0a2bd94afaa02ce1c99089250d4832) <code>add `no-duplicate-headings-in-section` rule</code>
  * [`ad6bd2c`](https://github.com/whizark/remark-preset/commit/ad6bd2cda32158f4dce59ec61dcd50439bc6ddba) <code>add `no-reference-like-url` rule</code>
  * [`79a39d9`](https://github.com/whizark/remark-preset/commit/79a39d9ba2b7567ee10107f7c803b1e84d96ec20) <code>use string severity</code>

## October 26, 2016
  * [`27d121e`](https://github.com/whizark/remark-preset/commit/27d121ecf8892e9734431ba9e98df18f07f9e6f3) <code>drop Node v5, add v7 for Travis CI</code>

## October 23, 2016
  * [`06a7f8e`](https://github.com/whizark/remark-preset/commit/06a7f8e556ec9934e12750f4d8975da20b3e1f84) <code>bump version to 0.2.0</code>
  * [`0ece365`](https://github.com/whizark/remark-preset/commit/0ece3656ba9048f478547f8930040e350928d842) <code>disable output by default</code>
  * [`3a22019`](https://github.com/whizark/remark-preset/commit/3a220199e0b9c767d43743bbcd894dd7ace7d1d1) <code>fix missing `use strict`</code>
  * [`a55029c`](https://github.com/whizark/remark-preset/commit/a55029ce045f291375cc3e5837dbce84a08b9cdc) <code>fix npm API key for deployment</code>
  * [`5fd8d73`](https://github.com/whizark/remark-preset/commit/5fd8d7387000195cd4ce6c4d8b7f426cffc72f52) <code>bump version to 0.1.0</code>
  * [`d00e7da`](https://github.com/whizark/remark-preset/commit/d00e7daf6efc1cbaf8e17d959b82f359090bf6aa) <code>`require()` alias file in default lint preset</code>
  * [`0eca10f`](https://github.com/whizark/remark-preset/commit/0eca10fb79b32a54e210003c27812d63d654223f) <code>simplify plugin name key</code>
  * [`f2f9f94`](https://github.com/whizark/remark-preset/commit/f2f9f948fbb1d9198337a57421a90a511dc3adff) <code>add badges to readme</code>
  * [`7911c40`](https://github.com/whizark/remark-preset/commit/7911c40cd1353771fda884be2aa2d39198d2bcfe) <code>add Travis CI config file</code>
  * [`71efbfb`](https://github.com/whizark/remark-preset/commit/71efbfb94dd6bc3a9e555931b447fce13ed40003) <code>add (dev|peer)Dependencies</code>
  * [`a4c5173`](https://github.com/whizark/remark-preset/commit/a4c51731fa751f91df34ca7a6284af8fa753c6ed) <code>add preset files</code>

## October 22, 2016
  * [`ceb22ce`](https://github.com/whizark/remark-preset/commit/ceb22ce67da3ad7243a7739c410aa7724a6cafee) <code>add initial files</code>
  * [`2b1bc41`](https://github.com/whizark/remark-preset/commit/2b1bc41c90151a9fc745a16df464eed41e6631bd) <code>prepare repository</code>